### PR TITLE
Fix management of GDI with tracks with bad names

### DIFF
--- a/GDEmuSdCardManager.BLL/Extensions/StringExtensions.cs
+++ b/GDEmuSdCardManager.BLL/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.RegularExpressions;
+
+namespace GDEmuSdCardManager.BLL.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string RemoveSpacesInSuccession(this string str)
+        {
+            RegexOptions options = RegexOptions.None;
+            Regex regex = new Regex("[ ]{2,}", options);
+            return regex.Replace(str, " ");
+        }
+    }
+}

--- a/GDEmuSdCardManager.DTO/BaseGame.cs
+++ b/GDEmuSdCardManager.DTO/BaseGame.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GDEmuSdCardManager.DTO.GDI;
+using System;
 
 namespace GDEmuSdCardManager.DTO
 {
@@ -19,5 +20,6 @@ namespace GDEmuSdCardManager.DTO
         public string BootFile { get; set; }
         public string Producer { get; set; }
         public string GameName { get; set; }
+        public Gdi GdiInfo { get; set; }
     }
 }

--- a/GDEmuSdCardManager.DTO/GDEmuSdCardManager.DTO.csproj
+++ b/GDEmuSdCardManager.DTO/GDEmuSdCardManager.DTO.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/GDEmuSdCardManager.DTO/GDI/DiscTrack.cs
+++ b/GDEmuSdCardManager.DTO/GDI/DiscTrack.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace GDEmuSdCardManager.DTO.GDI
+{
+    public class DiscTrack
+    {
+        /// <summary>
+        /// First column.
+        /// </summary>
+        public uint TrackNumber { get; set; }
+
+        /// <summary>
+        /// Location of extent. Second column
+        /// </summary>
+        public uint Lba { get; set; }
+
+        /// <summary>
+        /// Either 2048 or 2352. Third column.
+        /// </summary>
+        public int SectorSize { get; set; }
+
+        /// <summary>
+        /// Define the type of the file. Third column.
+        /// 0 is audio (raw) and 4 is data (bin or iso).
+        /// </summary>
+        public byte TrackType { get; set; }
+
+        /// <summary>
+        /// Name of the file. Fourth column
+        /// </summary>
+        public string FileName { get; set; }
+
+        public string FileExtension
+        {
+            get
+            {
+                return Path.GetExtension(FileName);
+            }
+        }
+
+        public string StandardName
+        {
+            get
+            {
+                return "track" + TrackNumber.ToString("D2") + FileExtension;
+            }
+        }
+    }
+}

--- a/GDEmuSdCardManager.DTO/GDI/Gdi.cs
+++ b/GDEmuSdCardManager.DTO/GDI/Gdi.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace GDEmuSdCardManager.DTO.GDI
+{
+    public class Gdi
+    {
+        public int NumberOfTracks { get; set; }
+        public List<DiscTrack> Tracks { get; set; }
+
+        public void SaveTo(string path, bool renameTrackName)
+        {
+            using (var sw = new StreamWriter(path))
+            {
+                sw.WriteLine(NumberOfTracks);
+                foreach (var track in Tracks)
+                {
+                    string trackName = renameTrackName ?
+                        track.StandardName :
+                        track.FileName;
+
+                    sw.WriteLine(track.TrackNumber + " " + track.Lba + " " + track.TrackType + " " + track.SectorSize + " " + trackName + " 0");
+                }
+            }
+        }
+
+        public void RenameTrackFiles(string path)
+        {
+            foreach(var track in Tracks)
+            {
+                File.Move(Path.Combine(path, track.FileName), Path.Combine(path, track.StandardName));
+            }
+        }
+    }
+}

--- a/GDEmuSdCardManager/MainWindow.xaml.cs
+++ b/GDEmuSdCardManager/MainWindow.xaml.cs
@@ -239,11 +239,7 @@ namespace GDEmuSdCardManager
             var sdCardManager = new SdCardManager(SdFolderComboBox.SelectedItem as string);
 
             var pcGames = PcFoldersWithGdiListView.SelectedItems.Cast<GameOnPc>().ToList();
-            var gamesToCopy = pcGames
-                .Where(si => !gamesOnSdCard.Any(f => f.GameName == si.GameName && f.Disc == si.Disc)
-                || (si.FormattedSize != si.SdFormattedSize)
-                || si.MustShrink);
-
+            var gamesToCopy = pcGames;
             WriteInfo($"Copying {gamesToCopy.Count()} game(s) to SD card...");
 
             CopyProgressLabel.Visibility = Visibility.Visible;
@@ -273,7 +269,7 @@ namespace GDEmuSdCardManager
 
                 try
                 {
-                    await sdCardManager.AddGame(selectedItem.FullPath, index, selectedItem.MustShrink);
+                    await sdCardManager.AddGame(selectedItem, index);
                     CopyProgressBar.Value++;
                     WriteInfo($"{CopyProgressBar.Value}/{gamesToCopy.Count()} games copied");
                 }


### PR DESCRIPTION
* Added a GDI and a DiscTrack class to help reading and writing in thoses files.
* Track files are now renamed when they copied to the SD card to improve compatibility with some dumps. After that, GDEmu and SD Card Maker can read the files on the SD even if the file names were uncompatibles at first.