### PR TITLE
Fix CDI header analysis for old versions of CDI (before 2147483654)

### DIFF
--- a/GDEmuSdCardManager.BLL/ImageReaders/CdiReader.cs
+++ b/GDEmuSdCardManager.BLL/ImageReaders/CdiReader.cs
@@ -79,7 +79,14 @@ namespace GDEmuSdCardManager.BLL.ImageReaders
             cdiStream.Read(buffer4, 0, 4);
             uint headerOffset = BitConverter.ToUInt32(buffer4);
 
-            cdiStream.Seek(length - headerOffset, SeekOrigin.Begin);
+            if (cdiVersion >= 2147483654)
+            {
+                cdiStream.Seek(length - headerOffset, SeekOrigin.Begin);
+            }
+            else
+            {
+                cdiStream.Seek(headerOffset, SeekOrigin.Begin);
+            }
 
             cdiStream.Read(buffer2, 0, 2);
             ushort numberOfSessions = BitConverter.ToUInt16(buffer2);


### PR DESCRIPTION
Will fix the common error with the message "Cannot manage CDI with something else than two sessions." even though the number of sessions is good.

Closes #68 